### PR TITLE
devcontainerが動かなかったので

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ FROM mcr.microsoft.com/devcontainers/base:noble AS devcontainer
 RUN apt-get update
 
 # Add sudoers (for post_create_custom.sh)
-RUN echo "ubuntu ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/ubuntu
+RUN echo "vscode ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/vscode
 
 # Install network tools
 RUN apt-get install -y iputils-ping net-tools

--- a/.devcontainer/development/devcontainer.json
+++ b/.devcontainer/development/devcontainer.json
@@ -4,16 +4,16 @@
   "service": "devcontainer",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "/workspace/.devcontainer/post_create.sh",
-  "remoteUser": "ubuntu",
+  "remoteUser": "vscode",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/ubuntu/.ssh,readonly,type=bind"
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached,uid=1000,gid=1000"
   ],
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "20.16.0",
+      "version": "lts",
       "nvmVersion": "latest"
     }
   },

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -21,6 +21,12 @@ BACKEND_PACKAGE_PATH="${WORKSPACE_PATH}/backend"
 FRONTEND_PACKAGE_PATH="${WORKSPACE_PATH}/frontend"
 CUSTOM_POST_CREATE_SCRIPT_PATH="${WORKSPACE_PATH}/.devcontainer/post_create_custom.sh"
 
+# SSH ディレクトリのパーミッションを設定
+chmod 700 /home/vscode/.ssh
+find /home/vscode/.ssh -type f -exec chmod 600 {} \;
+find /home/vscode/.ssh -name "*.pub" -exec chmod 644 {} \;
+chown -R vscode:vscode /home/vscode/.ssh
+
 # 各パッケージの package.json を参照して pnpm と依存関係をインストールする
 echo "Install spec dependencies..."
 cd "$SPEC_PACKAGE_PATH"

--- a/.devcontainer/test/devcontainer.json
+++ b/.devcontainer/test/devcontainer.json
@@ -4,11 +4,11 @@
   "service": "devcontainer",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "/workspace/.devcontainer/post_create.sh",
-  "remoteUser": "ubuntu",
+  "remoteUser": "vscode",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/ubuntu/.ssh,readonly,type=bind"
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached,uid=1000,gid=1000"
   ],
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {


### PR DESCRIPTION
- [`vscode`がおるよ](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/README.md#using-this-image:~:text=a%20non%2Droot%20vscode%20user%20with%20sudo%20access)
- pnpmがコケてたのでdevelopmentのnode versionをltsに変更
- .sshがrootになってたのでvscodeになるように変更